### PR TITLE
Remove @pygreece from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Global Owners
-* @pygreece @thepetk @lysnikolaou @gzisopoulos
+* @thepetk @lysnikolaou @gzisopoulos


### PR DESCRIPTION
Let's remove @pygreece from CODEOWNERS, since we'll never log in from that account to review.