### PR TITLE
docs: initialize git submodules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ git clone --recursive git@github.com:<το username σας>/python-docs-el.git
 cd python-docs-el/
 ```
 
-4. Aρχικοποιήσετε το περιεχόμενο των υπο-ενοτήτων (submodules) για να κατέβουν τα απαραίτητα αρχεία.
+4. Aρχικοποιήστε το περιεχόμενο των υπο-ενοτήτων (submodules) για να κατέβουν τα απαραίτητα αρχεία.
 
 ```bash
 git submodule update --init --recursive --depth 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,13 +47,19 @@ git clone --recursive git@github.com:<το username σας>/python-docs-el.git
 cd python-docs-el/
 ```
 
-4. Προσθέστε το επίσημο repository ως upstream:
+4. Aρχικοποιήσετε το περιεχόμενο των υπο-ενοτήτων (submodules) για να κατέβουν τα απαραίτητα αρχεία.
+
+```bash
+git submodule update --init --recursive
+```
+
+5. Προσθέστε το επίσημο repository ως upstream:
 
 ```bash
 git remote add upstream git@github.com:python/python-docs-el.git
 ```
 
-5. Προσθέστε το κατάλληλο URL για το upstream repository σας:
+6. Προσθέστε το κατάλληλο URL για το upstream repository σας:
 
 ```bash
 git remote set-url --push upstream git@github.com:<your-username>/cpython.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ cd python-docs-el/
 4. Aρχικοποιήσετε το περιεχόμενο των υπο-ενοτήτων (submodules) για να κατέβουν τα απαραίτητα αρχεία.
 
 ```bash
-git submodule update --init --recursive
+git submodule update --init --recursive --depth 1
 ```
 
 5. Προσθέστε το επίσημο repository ως upstream:


### PR DESCRIPTION
## Ποιο issue κλείνει το συγκεκριμένο PR;

Closes #1129

## Περιγραφή του PR

This PR updates the setup instructions to include missing steps for submodule initialization.

**Changes:**
- Added a mandatory step to initialize and update submodules.
- Fixes the "File Not Found" error occurring during `pip install -r requirements.txt`.

The guide now correctly instructs users to run:
`git submodule update --init --recursive`
This ensures the `cpython` directory is populated with the necessary files before installing dependencies.

**Validation:**
- Verified that a clean clone successfully installs all requirements after running the submodule update command.